### PR TITLE
added unpin to org-roam in packages.el

### DIFF
--- a/.doom.d/packages.el
+++ b/.doom.d/packages.el
@@ -45,3 +45,4 @@
 ;; This is required for some packages whose default branch isn't 'master' (which
 ;; our package manager can't deal with; see raxod502/straight.el#279)
 ;(package! builtin-package :recipe (:branch "develop"))
+(unpin! org-roam)


### PR DESCRIPTION
Doom's Packages are pinned to a specific commit and updated from release to release. You need to explicitly unpin packages if you want them to be updated